### PR TITLE
Auto-notify Developers of Incident Assignment in Slack via ManagerBot

### DIFF
--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerSlashService.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerSlashService.java
@@ -5,6 +5,7 @@ import com.innovactions.incident.adapter.security.EncryptionAdapter;
 import com.innovactions.incident.application.command.CloseIncidentCommand;
 import com.innovactions.incident.domain.model.Status;
 import com.innovactions.incident.port.inbound.IncidentInboundPort;
+import com.innovactions.incident.port.outbound.IncidentBroadcasterPort;
 import com.innovactions.incident.port.outbound.IncidentPersistencePort;
 import com.innovactions.incident.port.outbound.UserInfoPort;
 import java.time.format.DateTimeFormatter;
@@ -31,6 +32,7 @@ public class SlackManagerSlashService {
   private final EncryptionAdapter encryptionAdapter;
   private final UserInfoPort userInfoPort;
   private final IncidentInboundPort incidentInboundPort;
+  private final IncidentBroadcasterPort broadcaster;
 
   public String closeIncident(SlashCommandRequest request) {
     String userId = request.getUserId();
@@ -108,6 +110,12 @@ public class SlackManagerSlashService {
     }
 
     IncidentEntity incident = incidentOpt.get();
+
+    String channelId = incident.getSlackChannelId();
+
+    // notify developer of assignment by managerbot
+    broadcaster.notifyDeveloperOfAssignment(developerId, channelId);
+
     return String.format(
         "✅ Successfully assigned incident `%s` to <%s>\n" + "• *Status:* %s\n" + "• *Severity:* %s",
         incident.getId(), developerId, incident.getStatus(), incident.getSeverity());

--- a/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
@@ -117,4 +117,13 @@ public class SlackBroadcaster implements IncidentBroadcasterPort {
             + "Thank you for your cooperation!",
         IncidentActionBlocks.askForMoreInfoButtons());
   }
+
+  @Override
+  public void notifyDeveloperOfAssignment(String developerId, String channelId) {
+    managerBotMessagingPort.sendMessage(
+        developerId,
+        "✅ You have been assigned to a new incident by your manager. Please join the channel <#"
+            + channelId
+            + "> for details.");
+  }
 }

--- a/src/main/java/com/innovactions/incident/port/outbound/IncidentBroadcasterPort.java
+++ b/src/main/java/com/innovactions/incident/port/outbound/IncidentBroadcasterPort.java
@@ -11,4 +11,6 @@ public interface IncidentBroadcasterPort {
   void warnUserOfUnlinkedIncident(String reporterId);
 
   void askUserForMoreInfo(String reporterId, String details);
+
+  void notifyDeveloperOfAssignment(String developerId, String channelId);
 }


### PR DESCRIPTION
Senior developers can assign an incident task directly to developers on the Slack workspace. These developers need to be notified that they have been assigned this task, so that they can be invited in. There are two ways to do this:
1. Notify them with a link to join the channel.
2. Invite them directly as soon as task is assigned. 

Options can be discussed with stakeholder during sprint delivery.

> [!NOTE]
> The senior developer/manager who assigns the tasks will always be added to the incident channel. This can be changed later as preference of the stakeholder. To change who the Slack ID of the senior developer, change a secret variable in Azure with the name `SLACK_DEVELOPER_USER_ID`.

Changes in this commit:
- Made new method to notify developer of assignment via `ManagerBot`
- Added notify method to `assignIncident()`

Expected flow
1. Incident opened by a reporter
2. Senior developer assigns task to developer A
4. ManagerBot notifies developer A of assignment via private DM with link to join channel
5. Developer A sees notification, joins channel to work on incident