### PR TITLE
DebugController Fix + Channel Name Revision

### DIFF
--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerActions.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerActions.java
@@ -28,6 +28,17 @@ public class SlackManagerActions {
   private final IncidentPersistencePort incidentPersistencePort;
 
   public void register(App managerApp) {
+    // Log what Bolt actually sees (helps diagnose parsing/signature issues)
+    managerApp.use(
+        (req, ctx, chain) -> {
+          log.info("=== SLACK MANAGER REQUEST DEBUG ===");
+          log.info("Request type: {}", req.getRequestType());
+          log.info("Request headers: {}", req.getHeaders());
+          log.info("Request raw body: {}", req.getRequestBodyAsString());
+          log.info("=== END DEBUG ===");
+          return chain.next(req);
+        });
+
     managerApp.blockAction(
         "ack_incident",
         (req, ctx) -> {

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerSlashService.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackManagerSlashService.java
@@ -154,7 +154,7 @@ public class SlackManagerSlashService {
           incident.getAssignee() == null || incident.getAssignee().isBlank()
               ? "Pending"
               : incident.getAssignee();
-      String assigneeDisplay = ("Pending".equals(assignee)) ? "Pending" : "<" + assignee + ">";
+      String assigneeDisplay = ("Pending".equals(assignee)) ? "Pending" : "<@" + assignee + ">";
 
       sb.append(String.format("• *ID:* `%s`\n", incident.getId()));
       sb.append(String.format("  *Reporter:* %s\n", reporterDisplay));

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
@@ -128,7 +128,7 @@ public class SlackReporterFlow {
                             userId, reporterName, text, Instant.now(), Platform.SLACK);
                     incidentInboundPort.reportIncident(command);
                   } catch (Exception e) {
-                    // pass
+                    log.error("Error reporting incident: {}", e.getMessage(), e);
                   } finally {
                     pendingReportState.clearPending(userId);
                   }
@@ -150,7 +150,7 @@ public class SlackReporterFlow {
                       broadcaster.warnUserOfUnlinkedIncident(updateCommand.reporterId());
                     }
                   } catch (Exception e) {
-                    // pass
+                    log.error("Error updating incident: {}", e.getMessage(), e);
                   } finally {
                     pendingReportState.clearUpdating(userId);
                   }

--- a/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
+++ b/src/main/java/com/innovactions/incident/adapter/inbound/slack/SlackReporterFlow.java
@@ -12,6 +12,7 @@ import com.slack.api.model.event.MessageEvent;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
  *
  * <p>Used with the Reporter Bot in client context
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SlackReporterFlow {
@@ -29,6 +31,17 @@ public class SlackReporterFlow {
   private final IncidentBroadcasterPort broadcaster;
 
   public void register(App app) {
+    // Log what Bolt actually sees (helps diagnose parsing/signature issues)
+    app.use(
+        (req, ctx, chain) -> {
+          log.info("=== SLACK REPORTER REQUEST DEBUG ===");
+          log.info("Request type: {}", req.getRequestType());
+          log.info("Request headers: {}", req.getHeaders());
+          log.info("Request raw body: {}", req.getRequestBodyAsString());
+          log.info("=== END DEBUG ===");
+          return chain.next(req);
+        });
+
     // report_bug --> mark pending and prompt for details
     app.blockAction(
         "report_bug",

--- a/src/main/java/com/innovactions/incident/adapter/outbound/AI/GeminiIncidentClassifier.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/AI/GeminiIncidentClassifier.java
@@ -27,7 +27,7 @@ public class GeminiIncidentClassifier implements SeverityClassifierPort {
         """
                 You are an incident triage assistant.
 
-                Analyze the incident report and respond ONLY in valid JSON
+                Analyze the incident report and respond ONLY in valid JSON without Markdown formatting.
                 using the following schema:
 
                 {

--- a/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
@@ -28,7 +28,9 @@ public class SlackBroadcaster implements IncidentBroadcasterPort {
   @Override
   public String initSlackDeveloperWorkspace(Incident incident, Platform platform) {
     // generate channel name based on severity and reporter name
-    String channelName = channelNameGenerator.generateChannelName(incident.getSeverity(), incident.getReporterName());
+    String channelName =
+        channelNameGenerator.generateChannelName(
+            incident.getSeverity(), incident.getReporterName());
 
     // create new channel in workspace B
     String channelId = channelAdministrationPort.createPublicChannel(channelName);

--- a/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
+++ b/src/main/java/com/innovactions/incident/adapter/outbound/Slack/SlackBroadcaster.java
@@ -27,8 +27,8 @@ public class SlackBroadcaster implements IncidentBroadcasterPort {
 
   @Override
   public String initSlackDeveloperWorkspace(Incident incident, Platform platform) {
-    // generate channel name based on severity and timestamp
-    String channelName = channelNameGenerator.generateChannelName(incident.getSeverity());
+    // generate channel name based on severity and reporter name
+    String channelName = channelNameGenerator.generateChannelName(incident.getSeverity(), incident.getReporterName());
 
     // create new channel in workspace B
     String channelId = channelAdministrationPort.createPublicChannel(channelName);

--- a/src/main/java/com/innovactions/incident/config/SlackConfig.java
+++ b/src/main/java/com/innovactions/incident/config/SlackConfig.java
@@ -24,6 +24,7 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 
 @Configuration
 public class SlackConfig {
@@ -113,12 +114,22 @@ public class SlackConfig {
   ───────────────────────────────────── */
   @Bean
   public ServletRegistrationBean<Servlet> reporterServlet(App reporterSlackApp) {
-    return new ServletRegistrationBean<>(new SlackAppServlet(reporterSlackApp), "/slack/reporter");
+    ServletRegistrationBean<Servlet> registration =
+        new ServletRegistrationBean<>(new SlackAppServlet(reporterSlackApp), "/slack/reporter");
+    // Ensure the Bolt servlet is initialized early and wins deterministically
+    registration.setLoadOnStartup(1);
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registration;
   }
 
   @Bean
   public ServletRegistrationBean<Servlet> managerServlet(App managerSlackApp) {
-    return new ServletRegistrationBean<>(new SlackAppServlet(managerSlackApp), "/slack/manager");
+    ServletRegistrationBean<Servlet> registration =
+        new ServletRegistrationBean<>(new SlackAppServlet(managerSlackApp), "/slack/manager");
+    // Ensure the Bolt servlet is initialized early and wins deterministically
+    registration.setLoadOnStartup(1);
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registration;
   }
 
   /* ─────────────────────────────────────

--- a/src/main/java/com/innovactions/incident/controller/DebugController.java
+++ b/src/main/java/com/innovactions/incident/controller/DebugController.java
@@ -1,0 +1,38 @@
+package com.innovactions.incident.controller;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DebugController {
+  @PostMapping("/slack/reporter")
+  public String debugSlackRequest(
+      @RequestHeader Map<String, String> headers, @RequestBody(required = false) String body) {
+
+    System.out.println("=== DEBUG: Raw request received ===");
+    System.out.println("Headers:");
+    headers.forEach((key, value) -> System.out.println("  " + key + ": " + value));
+
+    System.out.println("Body: " + (body != null ? body : "null"));
+    System.out.println("=== END DEBUG ===");
+
+    return "Debug reporter endpoint received request";
+  }
+
+  @PostMapping("/slack/manager")
+  public String debugSlackManagerRequest(
+      @RequestHeader Map<String, String> headers, @RequestBody(required = false) String body) {
+
+    System.out.println("=== DEBUG: Raw manager request received ===");
+    System.out.println("Headers:");
+    headers.forEach((key, value) -> System.out.println("  " + key + ": " + value));
+
+    System.out.println("Body: " + (body != null ? body : "null"));
+    System.out.println("=== END DEBUG ===");
+
+    return "Debug manager endpoint received request";
+  }
+}

--- a/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
+++ b/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
@@ -2,8 +2,8 @@ package com.innovactions.incident.domain.service;
 
 import com.innovactions.incident.domain.model.Severity;
 import java.time.LocalDateTime;
-import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -15,15 +15,12 @@ public class ChannelNameGenerator {
     String day = String.format("%02d", now.getDayOfMonth());
     String month = String.format("%02d", now.getMonthValue());
     String year = String.valueOf(now.getYear());
-    
+
     String sanitizedName = sanitizeForChannelName(reporterName);
     log.info("Sanitized name: {}", sanitizedName);
 
     return String.format(
-        "%s_%s_%s-%s-%s", 
-        severity.name().toLowerCase(), 
-        sanitizedName,
-        day, month, year);
+        "%s_%s_%s-%s-%s", severity.name().toLowerCase(), sanitizedName, day, month, year);
   }
 
   private String sanitizeForChannelName(String name) {
@@ -31,11 +28,11 @@ public class ChannelNameGenerator {
       return "unknown";
     }
     // Slack channel names: lowercase, max 80 chars, alphanumeric + hyphens/underscores
-    String sanitized = name
-        .toLowerCase()
-        .replaceAll("[^a-z0-9-_]", "_")
-        .replaceAll("_{2,}", "_")
-        .replaceAll("^_|_$", "");
+    String sanitized =
+        name.toLowerCase()
+            .replaceAll("[^a-z0-9-_]", "_")
+            .replaceAll("_{2,}", "_")
+            .replaceAll("^_|_$", "");
 
     return sanitized.substring(0, Math.min(30, sanitized.length()));
   }

--- a/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
+++ b/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
@@ -3,20 +3,40 @@ package com.innovactions.incident.domain.service;
 import com.innovactions.incident.domain.model.Severity;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 public class ChannelNameGenerator {
 
-  public String generateChannelName(Severity severity) {
+  public String generateChannelName(Severity severity, String reporterName) {
     LocalDateTime now = LocalDateTime.now();
 
     String day = String.format("%02d", now.getDayOfMonth());
     String month = String.format("%02d", now.getMonthValue());
     String year = String.valueOf(now.getYear());
-    String hour = String.format("%02d", now.getHour());
-    String minute = String.format("%02d", now.getMinute());
+    
+    String sanitizedName = sanitizeForChannelName(reporterName);
+    log.info("Sanitized name: {}", sanitizedName);
 
     return String.format(
-        "%s_%s-%s-%s_%s-%s", severity.name().toLowerCase(), day, month, year, hour, minute);
+        "%s_%s_%s-%s-%s", 
+        severity.name().toLowerCase(), 
+        sanitizedName,
+        day, month, year);
+  }
+
+  private String sanitizeForChannelName(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      return "unknown";
+    }
+    // Slack channel names: lowercase, max 80 chars, alphanumeric + hyphens/underscores
+    String sanitized = name
+        .toLowerCase()
+        .replaceAll("[^a-z0-9-_]", "_")
+        .replaceAll("_{2,}", "_")
+        .replaceAll("^_|_$", "");
+
+    return sanitized.substring(0, Math.min(30, sanitized.length()));
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=incident-backend
-
+spring.docker.compose.enabled=false
 
 # DB Configuration
-spring.datasource.url=jdbc:${db-con-string}
-spring.datasource.username=${db-username}
-spring.datasource.password=${db-password}
+spring.datasource.url=jdbc:postgresql://localhost:5432/incident_db
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,18 +1,19 @@
+# spring:
+#   cloud.azure:
+#     credential:
+#       managed-identity-enabled: false
+#     keyvault:
+#       secret:
+#         property-source-enabled: true
+#         property-sources:
+#           - endpoint: https://innovactions-secrets.vault.azure.net/
+#             retry:
+#               mode: exponential
+#               exponential:
+#                 max-retries: 4
+#                 base-delay: PT0.0801S
+#                 max-delay: PT9S
 spring:
-  cloud.azure:
-    credential:
-      managed-identity-enabled: false
-    keyvault:
-      secret:
-        property-source-enabled: true
-        property-sources:
-          - endpoint: https://innovactions-secrets.vault.azure.net/
-            retry:
-              mode: exponential
-              exponential:
-                max-retries: 4
-                base-delay: PT0.0801S
-                max-delay: PT9S
   docker:
     compose:
       enabled: false

--- a/src/test/java/com/innovactions/incident/domain/service/ChannelNameGeneratorTest.java
+++ b/src/test/java/com/innovactions/incident/domain/service/ChannelNameGeneratorTest.java
@@ -23,10 +23,10 @@ class ChannelNameGeneratorTest {
       ChannelNameGenerator generator = new ChannelNameGenerator();
 
       // When
-      String channel = generator.generateChannelName(Severity.MAJOR);
+      String channel = generator.generateChannelName(Severity.MAJOR, "test");
 
       // Then
-      assertEquals("major_03-11-2025_07-05", channel);
+      assertEquals("major_test_03-11-2025", channel);
     }
   }
 
@@ -40,10 +40,10 @@ class ChannelNameGeneratorTest {
       mocked.when(() -> LocalDateTime.now()).thenReturn(fixed);
 
       ChannelNameGenerator gen = new ChannelNameGenerator();
-      String result = gen.generateChannelName(Severity.MINOR);
+      String result = gen.generateChannelName(Severity.MINOR, "test");
 
       // Then
-      assertEquals("minor_02-01-2025_03-04", result);
+      assertEquals("minor_test_02-01-2025", result);
     }
   }
 
@@ -53,7 +53,7 @@ class ChannelNameGeneratorTest {
     var gen = new ChannelNameGenerator();
 
     // When, Then
-    assertThatThrownBy(() -> gen.generateChannelName(null))
+    assertThatThrownBy(() -> gen.generateChannelName(null, "test"))
         .isInstanceOf(NullPointerException.class) // or IllegalArgumentException if you add a guard
         .hasMessageContaining("severity"); // add a message in your guard for clarity
   }


### PR DESCRIPTION
**First commit changes**:
Fixed the request body and headers stripped by implementing a `DebugController` controller class to see incoming headers and body contents to Slack Bolt.

> [!NOTE]
> Azure Vault configuration in `application.yaml` file was commented since the credits ran out. 

**Second commit changes**:
- Changed the `GeminiIncidentClassifier` to return only JSON without markdown formatting (caused bugs)
- Changed `SlackBroadcaster` to include `reporterName` parameter in channel name generation
- Added `reporterName` to channel name in `generateChannelName()`
- Added method `sanitizeForChannelName()` to sanitize name input in case invalid characters appear
- Added `log.error()` to `CompletableFuture.runAsync()` in `SlackReporterFlow`
- Changed channel generation tests to include test names

> [!WARNING]
> Please test WhatsApp and Email features with this new commit. Test creating an incident and double check the channel name in the logs. They should include reporter name with this new change.