### PR TITLE
Added time to create uniqueness to channel naming

### DIFF
--- a/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
+++ b/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
@@ -23,7 +23,8 @@ public class ChannelNameGenerator {
     log.info("Sanitized name: {}", sanitizedName);
 
     return String.format(
-        "%s_%s_%s-%s-%s_%s-%s-%s", severity.name().toLowerCase(), sanitizedName, day, month, year, hour, minute, second);
+        "%s_%s_%s-%s-%s_%s-%s-%s",
+        severity.name().toLowerCase(), sanitizedName, day, month, year, hour, minute, second);
   }
 
   private String sanitizeForChannelName(String name) {

--- a/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
+++ b/src/main/java/com/innovactions/incident/domain/service/ChannelNameGenerator.java
@@ -15,12 +15,15 @@ public class ChannelNameGenerator {
     String day = String.format("%02d", now.getDayOfMonth());
     String month = String.format("%02d", now.getMonthValue());
     String year = String.valueOf(now.getYear());
+    String hour = String.format("%02d", now.getHour());
+    String minute = String.format("%02d", now.getMinute());
+    String second = String.format("%02d", now.getSecond());
 
     String sanitizedName = sanitizeForChannelName(reporterName);
     log.info("Sanitized name: {}", sanitizedName);
 
     return String.format(
-        "%s_%s_%s-%s-%s", severity.name().toLowerCase(), sanitizedName, day, month, year);
+        "%s_%s_%s-%s-%s_%s-%s-%s", severity.name().toLowerCase(), sanitizedName, day, month, year, hour, minute, second);
   }
 
   private String sanitizeForChannelName(String name) {

--- a/src/test/java/com/innovactions/incident/domain/service/ChannelNameGeneratorTest.java
+++ b/src/test/java/com/innovactions/incident/domain/service/ChannelNameGeneratorTest.java
@@ -26,7 +26,7 @@ class ChannelNameGeneratorTest {
       String channel = generator.generateChannelName(Severity.MAJOR, "test");
 
       // Then
-      assertEquals("major_test_03-11-2025", channel);
+      assertEquals("major_test_03-11-2025_07-05-00", channel);
     }
   }
 
@@ -43,7 +43,7 @@ class ChannelNameGeneratorTest {
       String result = gen.generateChannelName(Severity.MINOR, "test");
 
       // Then
-      assertEquals("minor_test_02-01-2025", result);
+      assertEquals("minor_test_02-01-2025_03-04-00", result);
     }
   }
 


### PR DESCRIPTION
Small issue that channel naming wasn't unique by using time and date only, where there could be 2 incidents from the same user on the same day. So I added hour + minutes + seconds to the end of the string.